### PR TITLE
chore: Update Variable `state` to `contentState`

### DIFF
--- a/ios/ReactNativeActivityKit.m
+++ b/ios/ReactNativeActivityKit.m
@@ -3,7 +3,7 @@
 @interface RCT_EXTERN_MODULE(ReactNativeActivityKit, NSObject)
 
 RCT_EXTERN_METHOD(
-                  request:(NSString *)stateJSON
+                  request:(NSString *)contentStateJSON
                   withAttributesJSON:(NSString *)attributesJSON
                   withResolver:(RCTPromiseResolveBlock)resolve
                   withRejecter:(RCTPromiseRejectBlock)reject)
@@ -15,7 +15,7 @@ RCT_EXTERN_METHOD(
 
 RCT_EXTERN_METHOD(
                   update:(NSString *)activityId
-                  withStateJSON:(NSString *)stateJSON
+                  withContentStateJSON:(NSString *)contentStateJSON
                   withResolver:(RCTPromiseResolveBlock)resolve
                   withRejecter:(RCTPromiseRejectBlock)reject)
 

--- a/ios/ReactNativeActivityKit.swift
+++ b/ios/ReactNativeActivityKit.swift
@@ -34,12 +34,12 @@ class ReactNativeActivityKit: NSObject {
     }
     
     @objc(request:withAttributesJSON:withResolver:withRejecter:)
-    func request(stateJSON: String, attributesJSON: String, resolve: RCTPromiseResolveBlock,reject: RCTPromiseRejectBlock) -> Void {
+    func request(contentStateJSON: String, attributesJSON: String, resolve: RCTPromiseResolveBlock,reject: RCTPromiseRejectBlock) -> Void {
         // ActivtyKit is only available in iOS 16.1 or later
         if #available(iOS 16.1, *) {
             do {
                 let attributes = RNAKActivityAttributes(jsonString: attributesJSON)
-                let contentState = RNAKActivityAttributes.ContentState(jsonString: stateJSON)
+                let contentState = RNAKActivityAttributes.ContentState(jsonString: contentStateJSON)
                 
                 let activity = try Activity<RNAKActivityAttributes>.request(
                     attributes: attributes,
@@ -75,15 +75,15 @@ class ReactNativeActivityKit: NSObject {
         }
     }
     
-    @objc(update:withStateJSON:withResolver:withRejecter:)
-    func update(activityId: String, stateJSON: String, resolve: @escaping RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
+    @objc(update:withContentStateJSON:withResolver:withRejecter:)
+    func update(activityId: String, contentStateJSON: String, resolve: @escaping RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
         // ActivtyKit is only available in iOS 16.1 or later
         if #available(iOS 16.1, *) {
             Task {
                 if let activity = Activity<RNAKActivityAttributes>.activities.first(where: { activity in
                     return activity.id == activityId
                 }) {
-                    let updatedContentState = RNAKActivityAttributes.ContentState(jsonString: stateJSON)
+                    let updatedContentState = RNAKActivityAttributes.ContentState(jsonString: contentStateJSON)
 
                     await activity.update(using: updatedContentState)
                     

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,11 +23,11 @@ export function multiply(a: number, b: number): Promise<number> {
 }
 
 export function startActivity(
-  state: Record<string, unknown>,
+  contentState: Record<string, unknown>,
   attributes: Record<string, unknown> = {}
 ): Promise<ActivityKitActivity> {
   return ReactNativeActivityKit.request(
-    JSON.stringify(state),
+    JSON.stringify(contentState),
     JSON.stringify(attributes)
   ).then((res: string) => {
     try {
@@ -40,11 +40,11 @@ export function startActivity(
 
 export function updateActivity(
   identifier: string,
-  state: Record<string, unknown>
+  contentState: Record<string, unknown>
 ): Promise<ActivityKitActivity> {
   return ReactNativeActivityKit.update(
     identifier,
-    JSON.stringify(state)
+    JSON.stringify(contentState)
   ).then((res: string) => {
     try {
       return JSON.parse(res)


### PR DESCRIPTION
In an effort to keep consistent with conventions already established by Apple in the ActivityKit framework, we're renaming all references to the Activity state to `contentState` to match Apple's [docs](https://developer.apple.com/documentation/activitykit/activityattributes/contentstate)