### PR TITLE
feat: End All Activities

### DIFF
--- a/example/src/screens/Orders.tsx
+++ b/example/src/screens/Orders.tsx
@@ -10,6 +10,7 @@ import { X as CloseIcon } from 'react-native-feather';
 import { useAppSelector } from '../store/hooks';
 import { useNavigation } from '@react-navigation/native';
 
+import { endActivities } from 'react-native-activitykit'
 import Name from '../../assets/images/name.svg';
 
 import type { Order } from '../config/types';
@@ -56,6 +57,14 @@ const styles = StyleSheet.create({
   list: {
     marginHorizontal: 8,
   },
+  cancel: {
+    color: theme.colors.saucy,
+    fontWeight: 'bold',
+    fontSize: 10,
+    textAlign: 'center',
+    opacity: 0.5,
+    padding: 16
+  }
 });
 
 const renderItem = ({ item, navigation }: { item: Order; navigation: any }) => (
@@ -79,6 +88,14 @@ const Orders = () => {
 
   const orders = useAppSelector((state) => state.orders.orders);
 
+  async function cancelAllOrders() {
+    const activities = await endActivities({
+      dismissalPolicy: "immediate"
+    })
+
+    console.log("Cancel Orders", { activities })
+  }
+
   return (
     <View style={styles.container}>
       <View style={styles.header}>
@@ -93,6 +110,9 @@ const Orders = () => {
       </View>
       <View style={styles.list}>
         <FlatList
+          ListHeaderComponent={orders.length > 1 ? <TouchableOpacity onPress={cancelAllOrders}>
+            <Text style={styles.cancel}>Cancel All Orders</Text>
+          </TouchableOpacity> : null}
           data={orders}
           renderItem={({ item }) => renderItem({ item, navigation })}
         />

--- a/ios/ReactNativeActivityKit.m
+++ b/ios/ReactNativeActivityKit.m
@@ -21,6 +21,12 @@ RCT_EXTERN_METHOD(
                   withRejecter:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(
+                  endAll:(NSString *)contentStateJSON
+                  withDismissalPolicy:(NSString *)dismissalPolicy
+                  withResolver:(RCTPromiseResolveBlock)resolve
+                  withRejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(
                   update:(NSString *)activityId
                   withContentStateJSON:(NSString *)contentStateJSON
                   withResolver:(RCTPromiseResolveBlock)resolve

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -69,6 +69,20 @@ export function endActivity(identifier: string, options?: EndActivityOptions): P
   });
 }
 
+export function endActivities(options?: EndActivityOptions): Promise<ActivityKitActivity[]> {
+  const dismissalPolicy = options?.dismissalPolicy || "default"
+  const finalContentState = options?.finalContentState ? JSON.stringify(options.finalContentState) : ""
+
+  return ReactNativeActivityKit.endAll(finalContentState, dismissalPolicy).then((res: string) => {
+    try {
+      const activities: string[] = JSON.parse(res)
+      return activities.map((activity: string) => JSON.parse(activity))
+    } catch (e) {
+      throw new Error("[react-native-activitykit] Could not parse response from endActivities")
+    }
+  });
+}
+
 export const ActivityDismissalPolicies: Record<string, ActivityDismissalPolicy> = {
   default: 'default',
   immediate: 'immediate',


### PR DESCRIPTION
When there are multiple activities that you'd like to quickly end, use the `endActivities(options)` method in order to end all of them with a common set of options. 

This is especially helpful if you're cleaning things up and want to end all of them immediately to clear the Lock Screen